### PR TITLE
Moving mac process transformation code to wxEntry.

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -13,11 +13,6 @@
 #include "php_wxwidgets.h"
 #include "app.h"
 
-#ifdef __WXMAC__
-/* Header for process type transformation functions */
-#include <ApplicationServices/ApplicationServices.h>
-#endif
-
 /**
  * Set the wxWidgets application handler.
  */
@@ -84,18 +79,6 @@ int wxAppWrapper::OnExit()
 
 bool wxAppWrapper::OnInit()
 {
-     #ifdef __WXMAC__
-    /* In order to correctly receive keyboard input we need to explicitly
-     * tell mac to convert this console process to a gui process.
-     *
-     * Solution found at: 
-     * http://stackoverflow.com/questions/4341098/wxwidgets-commandline-gui-hybrid-application-fails-to-get-dialog-input
-     */
-    ProcessSerialNumber PSN;
-    GetCurrentProcess(&PSN);
-    TransformProcessType(&PSN,kProcessTransformToForegroundApplication);
-    #endif
-
     zval *retval;
     zval func_name;
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -15,6 +15,11 @@
 #include "php_wxwidgets.h"
 #include "functions.h"
 
+#ifdef __WXMAC__
+/* Header for process type transformation functions */
+#include <ApplicationServices/ApplicationServices.h>
+#endif
+
 #include "appmanagement.h"
 #include "aui.h"
 #include "bookctrl.h"
@@ -120,6 +125,18 @@ PHP_FUNCTION(php_wxExecute)
    This function initializes wxWidgets in a platform-dependent way. */
 PHP_FUNCTION(php_wxEntry)
 {
+	#ifdef __WXMAC__
+    /* In order to correctly receive keyboard input we need to explicitly
+     * tell mac to convert this console process to a gui process.
+     *
+     * Solution found at: 
+     * http://stackoverflow.com/questions/4341098/wxwidgets-commandline-gui-hybrid-application-fails-to-get-dialog-input
+     */
+    ProcessSerialNumber PSN;
+    GetCurrentProcess(&PSN);
+    TransformProcessType(&PSN,kProcessTransformToForegroundApplication);
+    #endif
+
 	int argc = 1;
 	char application_name[] = "wxPHP";
 	char *argv[2] = { application_name, NULL };

--- a/tools/source_maker/source_templates/app.cpp
+++ b/tools/source_maker/source_templates/app.cpp
@@ -13,11 +13,6 @@
 #include "php_wxwidgets.h"
 #include "app.h"
 
-#ifdef __WXMAC__
-/* Header for process type transformation functions */
-#include <ApplicationServices/ApplicationServices.h>
-#endif
-
 /**
  * Set the wxWidgets application handler.
  */
@@ -84,18 +79,6 @@ int wxAppWrapper::OnExit()
 
 bool wxAppWrapper::OnInit()
 {
-     #ifdef __WXMAC__
-    /* In order to correctly receive keyboard input we need to explicitly
-     * tell mac to convert this console process to a gui process.
-     *
-     * Solution found at: 
-     * http://stackoverflow.com/questions/4341098/wxwidgets-commandline-gui-hybrid-application-fails-to-get-dialog-input
-     */
-    ProcessSerialNumber PSN;
-    GetCurrentProcess(&PSN);
-    TransformProcessType(&PSN,kProcessTransformToForegroundApplication);
-    #endif
-
     zval *retval;
     zval func_name;
 

--- a/tools/source_maker/source_templates/functions.cpp
+++ b/tools/source_maker/source_templates/functions.cpp
@@ -15,6 +15,11 @@
 #include "php_wxwidgets.h"
 #include "functions.h"
 
+#ifdef __WXMAC__
+/* Header for process type transformation functions */
+#include <ApplicationServices/ApplicationServices.h>
+#endif
+
 <?php print $header_files ?>
 
 /**
@@ -81,6 +86,18 @@ PHP_FUNCTION(php_wxExecute)
    This function initializes wxWidgets in a platform-dependent way. */
 PHP_FUNCTION(php_wxEntry)
 {
+	#ifdef __WXMAC__
+    /* In order to correctly receive keyboard input we need to explicitly
+     * tell mac to convert this console process to a gui process.
+     *
+     * Solution found at: 
+     * http://stackoverflow.com/questions/4341098/wxwidgets-commandline-gui-hybrid-application-fails-to-get-dialog-input
+     */
+    ProcessSerialNumber PSN;
+    GetCurrentProcess(&PSN);
+    TransformProcessType(&PSN,kProcessTransformToForegroundApplication);
+    #endif
+
 	int argc = 1;
 	char application_name[] = "wxPHP";
 	char *argv[2] = { application_name, NULL };


### PR DESCRIPTION
The commit 684e773 broke wxPHP on OS X. I have moved the OS X process transformation code from OnInit to wxEntry with the help of @jgmdev.
