### PR TITLE
Updating docs for building on Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation: [http://github.com/wxphp/wxphp/wiki](http://github.com/wxphp/wxph
 * [Building and Installing on Linux/Unix Environments](#building-and-installing-on-linuxunix-environments)
 * [Creating a DEB Package](#creating-a-deb-package)
 * [Linking statically to wxWidgets on Linux/Unix/MacOSX](#linking-statically-to-wxwidgets-on-linuxunixmacosx)
-* [Building on Mac OS X](#building-on-macosx)
+* [Building on Mac OS X](#building-on-mac-os-x)
 * [Running the examples](#running-the-examples)
 * [Third Party Tools](#third-party-tools)
 * [Development](#development)


### PR DESCRIPTION
The docs for compiling wxPHP on Mac OS X are a little out of date.

I have updated them slightly in this PR.
