### PR TITLE
Adding travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+    - 5.6
+
+before_install:
+    - sudo apt-add-repository --yes ppa:zoogie/sdl2-snapshots
+    - sudo apt-get update
+
+install:
+   - sudo apt-get install libwebkitgtk-3.0-dev libgconf2-dev libghc-gstreamer-dev libsdl1.2-dev libgtk-3-dev
+
+script: phpize && ./configure && make && make test
+
+after_failure: cat wxWidgets-*/mybuild/config.log

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://img.shields.io/travis/wxphp/wxphp/master.svg?style=flat-square)](https://travis-ci.org/wxphp/wxphp)
+
 Site: [http://wxphp.org/](http://wxphp.org/)
 Documentation: [http://github.com/wxphp/wxphp/wiki](http://github.com/wxphp/wxphp/wiki)
 


### PR DESCRIPTION
Hey,

Just adding a travis.yml file and a build status image to the README.

This should be helpful for checking PR's don't break wxPHP builds and for running builds against multiple PHP versions automatically.

You'll need to enable the wxphp repo in travis.