### PR TITLE
Fix broken file clear function

### DIFF
--- a/examples/thread.php
+++ b/examples/thread.php
@@ -206,7 +206,7 @@ class ConvertFrame extends wxFrame {
 	function onClearClick( $event ){
 		if(wxMessageBox("Are you sure you want to clear the added files?", "", wxYES_NO) == wxYES)
 		{
-			$this->m_pdfList->Set(array(), null);
+			$this->m_pdfList->Clear();
 		}
 	}
 	


### PR DESCRIPTION
The `Set()` command here specified two parameters, when only one is necessary. In any case I've swapped it for `Clear()`, which is perhaps more appropriate.

The current `Set()` command results in this PHP error:

> PHP Fatal error:  Wrong type or count of parameters passed to: wxItemContainer::Set

Tested existing code and new code on `PHP 5.5.9-1ubuntu4.14 (cli) (built: Oct 28 2015 01:34:46)`.
