### PR TITLE
Add new sizers to sizer demo, tidy up control window

### DIFF
--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -52,7 +52,7 @@ class ControlFrame extends wxFrame
         $this->initAlignControls($sizer);
 
         // Put these controls in a frame
-        $frameSizer = $this->createFrameSizer("Border", wxVERTICAL);
+        $frameSizer = $this->createFrameSizer("Borders", wxVERTICAL);
         $this->initBorderSizeControl($frameSizer);
         $this->initBorderAddControls($frameSizer);
         $this->addItemToSizer($sizer, $frameSizer);
@@ -118,7 +118,7 @@ class ControlFrame extends wxFrame
     {
         $hSizer = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Border size:", wxDefaultPosition, new wxSize(-1, 18));
+            new wxStaticText($this, wxID_ANY, "Width:", wxDefaultPosition, new wxSize(-1, 18));
 
         // I'm leaving the spinner at a generous fixed with, since GTK renders it rather
         // wide otherwise
@@ -135,9 +135,6 @@ class ControlFrame extends wxFrame
     protected function initBorderAddControls(wxSizer $sizer)
     {
         $hSizer1 = new wxBoxSizer(wxHORIZONTAL);
-        $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Borders:", wxDefaultPosition, new wxSize(-1, 18));
-        $hSizer1->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
 
         // Add the first child sizer to the main one (going down)
         $sizer->Add($hSizer1, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -56,7 +56,7 @@ class ControlFrame extends wxFrame
         $this->initBorderSizeControl($frameSizer);
         $this->initBorderAddControls($frameSizer);
         $this->addItemToSizer($sizer, $frameSizer);
-        $this->SetSizer($sizer);
+        $this->SetSizerAndFit($sizer);
 
         // Save the help strings in this class too
         $this->helpStrings = $helpStrings;
@@ -114,7 +114,7 @@ class ControlFrame extends wxFrame
 
         // Add the controls to the child sizer (going across)
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxALL, 8);
-        $hSizer->Add($choiceCtrl, 0, wxLEFT + wxTOP + wxBOTTOM, 8);
+        $hSizer->Add($choiceCtrl, 0, wxALL, 8);
 
         return $choiceCtrl;
     }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -129,7 +129,8 @@ class ControlFrame extends wxFrame
         // Add the first child sizer to the main one (going down)
         $sizer->Add($hSizer1, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);
 
-        $hSizer2 = new wxBoxSizer(wxHORIZONTAL);
+        // Unlike a box sizer, a grid sizer doesn't seem to emit errors when adding checkboxes
+        $hSizer2 = new wxGridSizer(4, 0, 0);
 
         $this->initBorderAddControl($hSizer2, "Left");
         $this->initBorderAddControl($hSizer2, "Top");

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -65,6 +65,9 @@ class ControlFrame extends wxFrame
         $this->Connect(wxEVT_CHOICE, [$this, "controlChangeEvent"]);
         $this->Connect(wxEVT_SPINCTRL, [$this, "controlSpinEvent"]);
         $this->Connect(wxEVT_CHECKBOX, [$this, "controlCheckBoxEvent"]);
+
+        // Fixes redraw glitches just before the loop starts
+        $this->Layout();
     }
 
     /**

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -55,7 +55,7 @@ class ControlFrame extends wxFrame
         $frameSizer = $this->createFrameSizer("Border", wxVERTICAL);
         $this->initBorderSizeControl($frameSizer);
         $this->initBorderAddControls($frameSizer);
-        $sizer->Add($frameSizer, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8); // @todo Share code with same in initAlignControls
+        $this->addItemToSizer($sizer, $frameSizer);
         $this->SetSizer($sizer);
 
         // Save the help strings in this class too
@@ -77,7 +77,7 @@ class ControlFrame extends wxFrame
     protected function initAlignControls(wxSizer $sizer)
     {
         // Put these controls in a frame sizer
-        $hSizer = $this->createFrameSizer("Alignment", wxHORIZONTAL);
+        $hSizer = $this->createFrameSizer("Alignment", wxHORIZONTAL); // @todo Rename to $frameSizer
 
         $this->horizCtrl = $this->initAlignmentControl(
             $hSizer, 'H align:',
@@ -89,7 +89,7 @@ class ControlFrame extends wxFrame
         );
 
         // Add the child sizer to the main one (going down)
-        $sizer->Add($hSizer, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);
+        $this->addItemToSizer($sizer, $hSizer);
     }
 
     protected function initAlignmentControl(wxSizer $hSizer, $label, $choiceId, $choices)
@@ -104,7 +104,7 @@ class ControlFrame extends wxFrame
         $choiceCtrl->SetSelection(0);
 
         // Let's add left-spacing in the sizer if there's already controls in here
-        $leftSpace = $hSizer->GetItemCount() ? 16 : 0;
+        $leftSpace = $hSizer->GetItemCount() ? 16 : 0; // @todo Convert this to a conditional AddSpacer?
 
         // Add the controls to the child sizer (going across)
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxALL, 8);
@@ -129,7 +129,7 @@ class ControlFrame extends wxFrame
         $hSizer->Add($this->borderSizeCtrl);
 
         // Add the child sizer to the main one (going down)
-        $sizer->Add($hSizer, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);
+        $this->addItemToSizer($sizer, $hSizer);
     }
 
     protected function initBorderAddControls(wxSizer $sizer)
@@ -151,7 +151,7 @@ class ControlFrame extends wxFrame
         $this->initBorderAddControl($hSizer2, "Bottom");
 
         // Add the second child sizer to the main one (going down)
-        $sizer->Add($hSizer2, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);
+        $this->addItemToSizer($sizer, $hSizer2);
     }
 
     protected function initBorderAddControl(wxSizer $hSizer, $label)
@@ -306,5 +306,11 @@ class ControlFrame extends wxFrame
     protected function createFrameSizer($label, $orientation)
     {
         return new wxStaticBoxSizer(new wxStaticBox($this, wxID_ANY, $label), $orientation);
+    }
+
+    // @todo Type-hint $item as "wxSizer $childSizer"?
+    protected function addItemToSizer(wxSizer $sizer, $item)
+    {
+        $sizer->Add($item, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
     }
 }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -34,7 +34,7 @@ class ControlFrame extends wxFrame
             wxID_TOP,
             "Sizer controller",
             wxDefaultPosition,
-            new wxSize(350, 370),
+            new wxSize(380, 370),
             wxDEFAULT_DIALOG_STYLE
         );
         $this->SetPosition(new wxPoint(100, 100));
@@ -83,11 +83,11 @@ class ControlFrame extends wxFrame
         $hSizer = $this->createFrameSizer("Alignment", wxHORIZONTAL); // @todo Rename to $frameSizer
 
         $this->horizCtrl = $this->initAlignmentControl(
-            $hSizer, 'H align:',
+            $hSizer, 'Horizontal:',
             self::ID_HORIZ, ["Left", "Centre", "Right"]
         );
         $this->vertCtrl = $this->initAlignmentControl(
-            $hSizer, 'V align:',
+            $hSizer, 'Vertical:',
             self::ID_VERT, ["Top", "Centre", "Bottom"]
         );
 
@@ -109,13 +109,12 @@ class ControlFrame extends wxFrame
         // Let's add left-spacing in the sizer if there's already controls in here
         if ($hSizer->GetItemCount())
         {
-            $hSizer->AddSpacer(20);
+            $hSizer->AddSpacer(8);
         }
 
         // Add the controls to the child sizer (going across)
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxALL, 8);
-        $hSizer->AddSpacer(8);
-        $hSizer->Add($choiceCtrl, 0, wxALL, 8);
+        $hSizer->Add($choiceCtrl, 0, wxLEFT + wxTOP + wxBOTTOM, 8);
 
         return $choiceCtrl;
     }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -34,7 +34,7 @@ class ControlFrame extends wxFrame
             wxID_TOP,
             "Sizer controller",
             wxDefaultPosition,
-            new wxSize(350, 330),
+            new wxSize(350, 350),
             wxDEFAULT_DIALOG_STYLE
         );
         $this->SetPosition(new wxPoint(100, 100));
@@ -72,7 +72,10 @@ class ControlFrame extends wxFrame
      */
     protected function initAlignControls(wxSizer $sizer)
     {
-        $hSizer = new wxBoxSizer(wxHORIZONTAL);
+        // Put these controls in a frame sizer
+        $box = new wxStaticBox($this, wxID_ANY, "Alignment");
+        $hSizer = new wxStaticBoxSizer($box, wxHORIZONTAL);
+
         $this->horizCtrl = $this->initAlignmentControl(
             $hSizer, 'H align:',
             self::ID_HORIZ, ["Left", "Centre", "Right"]
@@ -101,9 +104,9 @@ class ControlFrame extends wxFrame
         $leftSpace = $hSizer->GetItemCount() ? 16 : 0;
 
         // Add the controls to the child sizer (going across)
-        $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxLEFT, $leftSpace);
+        $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxALL, 8);
         $hSizer->AddSpacer(8);
-        $hSizer->Add($choiceCtrl);
+        $hSizer->Add($choiceCtrl, 0, wxALL, 8);
 
         return $choiceCtrl;
     }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -41,7 +41,7 @@ class ControlFrame extends wxFrame
 
         // Create the main drop-down and help controls
         $this->choiceCtrl =
-            new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(-1, 29), $demoNames);
+            new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(-1, -1), $demoNames);
         $this->helpCtrl =
             new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(-1, 130));
 
@@ -99,9 +99,9 @@ class ControlFrame extends wxFrame
     {
         // The width of -1 means auto-size
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, 18));
+            new wxStaticText($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, -1));
         $choiceCtrl =
-            new wxChoice($this, $choiceId, wxDefaultPosition, new wxSize(-1, 29), $choices);
+            new wxChoice($this, $choiceId, wxDefaultPosition, new wxSize(-1, -1), $choices);
 
         // Select the first element for both alignment choosers
         $choiceCtrl->SetSelection(0);
@@ -123,12 +123,12 @@ class ControlFrame extends wxFrame
     {
         $hSizer = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Width:", wxDefaultPosition, new wxSize(-1, 18));
+            new wxStaticText($this, wxID_ANY, "Width:", wxDefaultPosition, new wxSize(-1, -1));
 
         // I'm leaving the spinner at a generous fixed with, since GTK renders it rather
         // wide otherwise
         $this->borderSizeCtrl =
-            new wxSpinCtrl($this, wxID_ANY, "8", wxDefaultPosition, new wxSize(100, 26), wxSP_ARROW_KEYS, 0, 12);
+            new wxSpinCtrl($this, wxID_ANY, "8", wxDefaultPosition, new wxSize(100, -1), wxSP_ARROW_KEYS, 0, 12);
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
         $hSizer->AddSpacer(8);
         $hSizer->Add($this->borderSizeCtrl);
@@ -159,7 +159,7 @@ class ControlFrame extends wxFrame
     protected function initBorderAddControl(wxSizer $hSizer, $label)
     {
         $checkBox =
-            new wxCheckBox($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, 24));
+            new wxCheckBox($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, -1));
         $checkBox->setValue(true);
         $hSizer->Add($checkBox);
 

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -34,7 +34,7 @@ class ControlFrame extends wxFrame
             wxID_TOP,
             "Sizer controller",
             wxDefaultPosition,
-            new wxSize(380, 370),
+            new wxSize(-1, 370),
             wxDEFAULT_DIALOG_STYLE
         );
         $this->SetPosition(new wxPoint(100, 100));

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -308,9 +308,8 @@ class ControlFrame extends wxFrame
         return new wxStaticBoxSizer(new wxStaticBox($this, wxID_ANY, $label), $orientation);
     }
 
-    // @todo Type-hint $item as "wxSizer $childSizer"?
-    protected function addItemToSizer(wxSizer $sizer, $item)
+    protected function addItemToSizer(wxSizer $sizer, wxSizer $childSizer)
     {
-        $sizer->Add($item, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
+        $sizer->Add($childSizer, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
     }
 }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -104,7 +104,10 @@ class ControlFrame extends wxFrame
         $choiceCtrl->SetSelection(0);
 
         // Let's add left-spacing in the sizer if there's already controls in here
-        $leftSpace = $hSizer->GetItemCount() ? 16 : 0; // @todo Convert this to a conditional AddSpacer?
+        if ($hSizer->GetItemCount())
+        {
+            $hSizer->AddSpacer(20);
+        }
 
         // Add the controls to the child sizer (going across)
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxALL, 8);

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -41,13 +41,14 @@ class ControlFrame extends wxFrame
 
         // Create the main drop-down and help controls
         $this->choiceCtrl =
-            new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(330, 29), $demoNames);
+            new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(-1, 29), $demoNames);
         $this->helpCtrl =
-            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(330, 130));
+            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(-1, 130));
 
         $sizer = new wxBoxSizer(wxVERTICAL);
-        $sizer->Add($this->choiceCtrl, 0, wxALL, 8);
-        $sizer->Add($this->helpCtrl, 0, wxLEFT + wxRIGHT + wxBOTTOM, 8);
+        // The menu and help controls are set to expand to the window width
+        $sizer->Add($this->choiceCtrl, 0, wxALL + wxEXPAND, 8);
+        $sizer->Add($this->helpCtrl, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
         $this->initAlignControls($sizer);
         $this->initBorderSizeControl($sizer);
         $this->initBorderAddControls($sizer);
@@ -87,10 +88,11 @@ class ControlFrame extends wxFrame
 
     protected function initAlignmentControl(wxSizer $hSizer, $label, $choiceId, $choices)
     {
+        // The width of -1 means auto-size
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(67, 18));
+            new wxStaticText($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, 18));
         $choiceCtrl =
-            new wxChoice($this, $choiceId, wxDefaultPosition, new wxSize(90, 29), $choices);
+            new wxChoice($this, $choiceId, wxDefaultPosition, new wxSize(-1, 29), $choices);
 
         // Select the first element for both alignment choosers
         $choiceCtrl->SetSelection(0);
@@ -100,6 +102,7 @@ class ControlFrame extends wxFrame
 
         // Add the controls to the child sizer (going across)
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL + wxLEFT, $leftSpace);
+        $hSizer->AddSpacer(8);
         $hSizer->Add($choiceCtrl);
 
         return $choiceCtrl;
@@ -109,10 +112,14 @@ class ControlFrame extends wxFrame
     {
         $hSizer = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Border size:", wxDefaultPosition, new wxSize(110, 18));
+            new wxStaticText($this, wxID_ANY, "Border size:", wxDefaultPosition, new wxSize(-1, 18));
+
+        // I'm leaving the spinner at a generous fixed with, since GTK renders it rather
+        // wide otherwise
         $this->borderSizeCtrl =
             new wxSpinCtrl($this, wxID_ANY, "8", wxDefaultPosition, new wxSize(100, 26), wxSP_ARROW_KEYS, 0, 12);
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
+        $hSizer->AddSpacer(8);
         $hSizer->Add($this->borderSizeCtrl);
 
         // Add the child sizer to the main one (going down)
@@ -123,7 +130,7 @@ class ControlFrame extends wxFrame
     {
         $hSizer1 = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Borders:", wxDefaultPosition, new wxSize(110, 18));
+            new wxStaticText($this, wxID_ANY, "Borders:", wxDefaultPosition, new wxSize(-1, 18));
         $hSizer1->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
 
         // Add the first child sizer to the main one (going down)
@@ -144,7 +151,7 @@ class ControlFrame extends wxFrame
     protected function initBorderAddControl(wxSizer $hSizer, $label)
     {
         $checkBox =
-            new wxCheckBox($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(80, 24));
+            new wxCheckBox($this, wxID_ANY, $label, wxDefaultPosition, new wxSize(-1, 24));
         $checkBox->setValue(true);
         $hSizer->Add($checkBox);
 

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -109,7 +109,7 @@ class ControlFrame extends wxFrame
     {
         $hSizer = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Border size: ", wxDefaultPosition, new wxSize(110, 18));
+            new wxStaticText($this, wxID_ANY, "Border size:", wxDefaultPosition, new wxSize(110, 18));
         $this->borderSizeCtrl =
             new wxSpinCtrl($this, wxID_ANY, "8", wxDefaultPosition, new wxSize(100, 26), wxSP_ARROW_KEYS, 0, 12);
         $hSizer->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
@@ -123,7 +123,7 @@ class ControlFrame extends wxFrame
     {
         $hSizer1 = new wxBoxSizer(wxHORIZONTAL);
         $labelCtrl =
-            new wxStaticText($this, wxID_ANY, "Borders: ", wxDefaultPosition, new wxSize(110, 18));
+            new wxStaticText($this, wxID_ANY, "Borders:", wxDefaultPosition, new wxSize(110, 18));
         $hSizer1->Add($labelCtrl, 0, wxALIGN_CENTER_VERTICAL);
 
         // Add the first child sizer to the main one (going down)

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -48,7 +48,7 @@ class ControlFrame extends wxFrame
         $sizer = new wxBoxSizer(wxVERTICAL);
         // The menu and help controls are set to expand to the window width
         $sizer->Add($this->choiceCtrl, 0, wxALL + wxEXPAND, 8);
-        $sizer->Add($this->helpCtrl, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
+        $sizer->Add($this->helpCtrl, 1, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
         $this->initAlignControls($sizer);
 
         // Put these controls in a frame

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -34,7 +34,7 @@ class ControlFrame extends wxFrame
             wxID_TOP,
             "Sizer controller",
             wxDefaultPosition,
-            new wxSize(350, 350),
+            new wxSize(350, 370),
             wxDEFAULT_DIALOG_STYLE
         );
         $this->SetPosition(new wxPoint(100, 100));
@@ -50,8 +50,12 @@ class ControlFrame extends wxFrame
         $sizer->Add($this->choiceCtrl, 0, wxALL + wxEXPAND, 8);
         $sizer->Add($this->helpCtrl, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8);
         $this->initAlignControls($sizer);
-        $this->initBorderSizeControl($sizer);
-        $this->initBorderAddControls($sizer);
+
+        // Put these controls in a frame
+        $frameSizer = $this->createFrameSizer("Border", wxVERTICAL);
+        $this->initBorderSizeControl($frameSizer);
+        $this->initBorderAddControls($frameSizer);
+        $sizer->Add($frameSizer, 0, wxLEFT + wxRIGHT + wxBOTTOM + wxEXPAND, 8); // @todo Share code with same in initAlignControls
         $this->SetSizer($sizer);
 
         // Save the help strings in this class too
@@ -73,8 +77,7 @@ class ControlFrame extends wxFrame
     protected function initAlignControls(wxSizer $sizer)
     {
         // Put these controls in a frame sizer
-        $box = new wxStaticBox($this, wxID_ANY, "Alignment");
-        $hSizer = new wxStaticBoxSizer($box, wxHORIZONTAL);
+        $hSizer = $this->createFrameSizer("Alignment", wxHORIZONTAL);
 
         $this->horizCtrl = $this->initAlignmentControl(
             $hSizer, 'H align:',
@@ -298,5 +301,10 @@ class ControlFrame extends wxFrame
         }
 
         return $flags;
+    }
+
+    protected function createFrameSizer($label, $orientation)
+    {
+        return new wxStaticBoxSizer(new wxStaticBox($this, wxID_ANY, $label), $orientation);
     }
 }

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -11,6 +11,10 @@ class ControlFrame extends wxFrame
     const ID_HORIZ = 10001;
     const ID_VERT = 10002;
 
+    // Guideline width for the help text. We can't set this to -1 otherwise using the Fit()
+    // feature makes it far too wide - maybe it prefers that to wrapping vertically?
+    const HELP_WIDTH = 330;
+
     // Callbacks for various events
     protected $changeDemohandler;
 
@@ -34,7 +38,7 @@ class ControlFrame extends wxFrame
             wxID_TOP,
             "Sizer controller",
             wxDefaultPosition,
-            new wxSize(-1, 370),
+            new wxSize(-1, -1),
             wxDEFAULT_DIALOG_STYLE
         );
         $this->SetPosition(new wxPoint(100, 100));
@@ -43,7 +47,7 @@ class ControlFrame extends wxFrame
         $this->choiceCtrl =
             new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(-1, -1), $demoNames);
         $this->helpCtrl =
-            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(-1, 130));
+            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(self::HELP_WIDTH, -1));
 
         $sizer = new wxBoxSizer(wxVERTICAL);
         // The menu and help controls are set to expand to the window width
@@ -209,6 +213,8 @@ class ControlFrame extends wxFrame
         $func($index, $this->getAlignmentFlags(), $this->getBorderAddFlags(), $this->getBorderSize());
 
         $this->demoIndex = $index;
+
+        $this->Fit();
     }
 
     /**
@@ -237,7 +243,7 @@ class ControlFrame extends wxFrame
 
         // The wrapping can change the control size, so it's worth asking the window
         // to re-layout its controls
-        $this->helpCtrl->Wrap(330);
+        $this->helpCtrl->Wrap(self::HELP_WIDTH);
         $this->Layout();
     }
 

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -11,11 +11,6 @@ class ControlFrame extends wxFrame
     const ID_HORIZ = 10001;
     const ID_VERT = 10002;
 
-    // Guideline width for the help text. We can't set this to -1 otherwise using the Fit()
-    // feature makes it far too wide - maybe it prefers that to wrapping vertically?
-    const HELP_WIDTH = 330;
-    protected $helpWidth = 330;
-
     // Callbacks for various events
     protected $changeDemohandler;
 
@@ -30,6 +25,10 @@ class ControlFrame extends wxFrame
     // Misc class properties
     protected $helpStrings;
     protected $demoIndex;
+
+    // Guideline width for the help text. We can't set this to -1 otherwise using the Fit()
+    // feature makes it far too wide - maybe it prefers that to wrapping vertically?
+    protected $helpWidth = 330;
 
     public function __construct(array $demoNames, array $helpStrings, $parent = null)
     {
@@ -48,7 +47,7 @@ class ControlFrame extends wxFrame
         $this->choiceCtrl =
             new wxChoice($this, self::ID_DEMO, wxDefaultPosition, new wxSize(-1, -1), $demoNames);
         $this->helpCtrl =
-            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize(self::HELP_WIDTH, -1));
+            new wxStaticText($this, wxID_ANY, '', wxDefaultPosition, new wxSize($this->helpWidth, -1));
 
         $sizer = new wxBoxSizer(wxVERTICAL);
         // The menu and help controls are set to expand to the window width

--- a/examples/sizers/control.php
+++ b/examples/sizers/control.php
@@ -249,8 +249,7 @@ class ControlFrame extends wxFrame
         $flags = 0;
 
         // Set the horizontal alignment flags
-        $horiz = $this->horizCtrl->GetSelection();
-        switch ($horiz)
+        switch ($this->getHorizAlignChoice())
         {
             case 0:
                 $flags += wxALIGN_LEFT;
@@ -264,8 +263,7 @@ class ControlFrame extends wxFrame
         }
 
         // Set the vertical alignment flags
-        $vert = $this->vertCtrl->GetSelection();
-        switch ($vert)
+        switch ($this->getVertAlignChoice())
         {
             case 0:
                 $flags += wxALIGN_TOP;
@@ -279,6 +277,16 @@ class ControlFrame extends wxFrame
         }
 
         return $flags;
+    }
+
+    protected function getHorizAlignChoice()
+    {
+        return $this->horizCtrl->GetSelection();
+    }
+
+    protected function getVertAlignChoice()
+    {
+        return $this->vertCtrl->GetSelection();
     }
 
     protected function getBorderSize()

--- a/examples/sizers/demo.php
+++ b/examples/sizers/demo.php
@@ -135,6 +135,7 @@ class DemoFrame extends wxFrame
             "Vert and horiz wxBoxSizers",
             "wxStaticBoxSizer",
             "wxGridSizer",
+            "wxFlexGridSizer"
         ];
     }
 
@@ -154,6 +155,7 @@ class DemoFrame extends wxFrame
             "Here we have an outer wxBoxSizer arranging blocks vertically, and one of the blocks is itself a wxBoxSizer that arranges its children rightwards.\n\nInterestingly, the child sizer seems to inherit its parent border width even though its own border is zero.",
             "A wxStaticBoxSizer operates in the same way as a wxBoxSizer, but draws a frame around the contents. This is useful to group related controls together.\n\nHere, this sizer is added to a box sizer so external border spacing can be added.",
             "The wxGridSizer uses the available width for a specified number of columns, then flows new elements onto the next row.\n\nThe rows are set to an equal height such that all available vertical space is utilised.",
+            "A wxFlexGridSizer is similar to a wxGridSizer, but rows take a height according to the tallest height in that row, and as such each row may be of a different height."
         ];
     }
 
@@ -223,10 +225,7 @@ class DemoFrame extends wxFrame
         // Generate the sizes if they're not already generated
         if (!$sizes)
         {
-            for ($i = 0; $i < 10; $i++)
-            {
-                $sizes[] = [rand(0, 25), rand(0, 50)];
-            }
+            $sizes = $this->generateRandomSizes(10, 25, 50);
         }
 
         $this->sizer = new wxGridSizer(4);
@@ -235,6 +234,43 @@ class DemoFrame extends wxFrame
         {
             $this->createBox("Item $ord", new wxSize(55 + $sizePair[0], 30 + $sizePair[1]));
         }
+    }
+
+    /**
+     * Demo of a FlexGridSizer
+     *
+     * @staticvar array $sizes
+     */
+    protected function demo_wxflexgridsizer()
+    {
+        static $sizes = array();
+
+        // Generate the sizes if they're not already generated
+        if (!$sizes)
+        {
+            $sizes = $this->generateRandomSizes(12, 25, 25);
+        }
+
+        $this->sizer = new wxFlexGridSizer(4);
+
+        foreach ($sizes as $ord => $sizePair)
+        {
+            $row = (int) ($ord / 4);
+            $this->createBox("Item $ord", new wxSize(55 + $sizePair[0], 25 + $row * 35 + $sizePair[1]));
+        }
+    }
+
+    protected function generateRandomSizes($count, $xRange, $yRange)
+    {
+        $sizes = array();
+        mt_srand(time());
+
+        for ($i = 0; $i < $count; $i++)
+        {
+            $sizes[] = [rand(0, $xRange), rand(0, $yRange)];
+        }
+
+        return $sizes;
     }
 
     protected function createSizerFlags($border = 0)

--- a/examples/sizers/demo.php
+++ b/examples/sizers/demo.php
@@ -121,6 +121,10 @@ class DemoFrame extends wxFrame
             $this->SetSizer($this->sizer);
             $this->Layout();
         }
+        else
+        {
+            trigger_error("No such demo", E_USER_WARNING);
+        }
     }
 
     public function getDemoNames()

--- a/examples/sizers/demo.php
+++ b/examples/sizers/demo.php
@@ -129,6 +129,7 @@ class DemoFrame extends wxFrame
             "Vertical wxBoxSizer",
             "Horizontal wxBoxSizer",
             "Vert and horiz wxBoxSizers",
+            "wxGridSizer",
         ];
     }
 
@@ -145,7 +146,8 @@ class DemoFrame extends wxFrame
         return [
             "This demontrates a wxBoxSizer that arranges elements in a vertical fashion.",
             "This demo shows a wxBoxSizer that arranges elements horizontally.",
-            "Here we have an outer wxBoxSizer arranging blocks vertically, and one of the blocks is itself a wxBoxSizer that arranges its children rightwards.\n\nInterestingly, the child sizer seems to inherit its parent border width even though its own border is zero."
+            "Here we have an outer wxBoxSizer arranging blocks vertically, and one of the blocks is itself a wxBoxSizer that arranges its children rightwards.\n\nInterestingly, the child sizer seems to inherit its parent border width even though its own border is zero.",
+            "The wxGridSizer uses the available width for a specified number of columns, then flows new elements onto the next row.\n\nThe rows are set to an equal height such that all available vertical space is utilised.",
         ];
     }
 
@@ -183,6 +185,35 @@ class DemoFrame extends wxFrame
         $this->createBox("Three", new wxSize(50, 30), $hSizer);
         $this->createBox("Four", new wxSize(100, 40), $hSizer);
         $this->createBox("Five", new wxSize(80, 100), $hSizer);
+    }
+
+    /**
+     * Demonstrates the grid sizer
+     *
+     * We generate the random sizes once, so that when we redraw (e.g. to change border
+     * options) the sizes don't jiggle all over the shop
+     *
+     * @staticvar array $sizes
+     */
+    protected function demo_wxgridsizer()
+    {
+        static $sizes = array();
+
+        // Generate the sizes if they're not already generated
+        if (!$sizes)
+        {
+            for ($i = 0; $i < 10; $i++)
+            {
+                $sizes[] = [rand(0, 25), rand(0, 50)];
+            }
+        }
+
+        $this->sizer = new wxGridSizer(4);
+
+        foreach ($sizes as $ord => $sizePair)
+        {
+            $this->createBox("Item $ord", new wxSize(55 + $sizePair[0], 30 + $sizePair[1]));
+        }
     }
 
     protected function createSizerFlags($border = 0)

--- a/examples/sizers/demo.php
+++ b/examples/sizers/demo.php
@@ -19,7 +19,7 @@ class DemoFrame extends wxFrame
             wxDefaultPosition,
             new wxSize(400, 300)
         );
-        $this->SetPosition(new wxPoint(500, 100));
+        $this->SetPosition(new wxPoint(600, 100));
     }
 
     protected function createBox($text, wxSize $size, wxSizer $sizer = null)

--- a/examples/sizers/demo.php
+++ b/examples/sizers/demo.php
@@ -129,6 +129,7 @@ class DemoFrame extends wxFrame
             "Vertical wxBoxSizer",
             "Horizontal wxBoxSizer",
             "Vert and horiz wxBoxSizers",
+            "wxStaticBoxSizer",
             "wxGridSizer",
         ];
     }
@@ -147,6 +148,7 @@ class DemoFrame extends wxFrame
             "This demontrates a wxBoxSizer that arranges elements in a vertical fashion.",
             "This demo shows a wxBoxSizer that arranges elements horizontally.",
             "Here we have an outer wxBoxSizer arranging blocks vertically, and one of the blocks is itself a wxBoxSizer that arranges its children rightwards.\n\nInterestingly, the child sizer seems to inherit its parent border width even though its own border is zero.",
+            "A wxStaticBoxSizer operates in the same way as a wxBoxSizer, but draws a frame around the contents. This is useful to group related controls together.\n\nHere, this sizer is added to a box sizer so external border spacing can be added.",
             "The wxGridSizer uses the available width for a specified number of columns, then flows new elements onto the next row.\n\nThe rows are set to an equal height such that all available vertical space is utilised.",
         ];
     }
@@ -185,6 +187,21 @@ class DemoFrame extends wxFrame
         $this->createBox("Three", new wxSize(50, 30), $hSizer);
         $this->createBox("Four", new wxSize(100, 40), $hSizer);
         $this->createBox("Five", new wxSize(80, 100), $hSizer);
+    }
+
+    protected function demo_wxstaticboxsizer()
+    {
+        $this->sizer = new wxBoxSizer(wxHORIZONTAL);
+
+        $box = new wxStaticBox($this, wxID_ANY, "Frame title");
+        $innerSizer = new wxStaticBoxSizer($box, wxHORIZONTAL);
+
+        // Add the child sizer to the main sizer, and set an outer border
+        $this->sizer->Add($innerSizer, $this->createSizerFlags($this->borderSize));
+
+        $this->createBox("One", new wxSize(100, 30), $innerSizer);
+        $this->createBox("Two", new wxSize(80, 60), $innerSizer);
+        $this->createBox("Three", new wxSize(80, 150), $innerSizer);
     }
 
     /**

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -28,6 +28,8 @@
  *      - make each FrameSizer a child of a new GridSizer
  *      - swap outer BoxSizer with FlexGridSizer with a single column
  *      - move window construction to Show()
+ *      - ** Ah, could wxEXPAND be the cause of these? Adding one resulted in 16 warnings
+ *        ** instead of 8!
  * @todo Right-align the alignment menu drop-downs, so that the vertical dropdown sits flush
  *      with the right hand edge of the frame (with an appropriate border of course)
  */

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -11,6 +11,10 @@
  *
  *     /usr/bin/php -d extension=wxwidgets.so sizers/main.php
  *
+ * For more information on how to use sizers generally, this article is excellent:
+ *
+ *     http://docs.wxwidgets.org/trunk/overview_sizer.html
+ *
  * @todo Remove trailing space to labels to add extra horiz space
  * @todo Quit when the controller window is closed
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -20,6 +20,9 @@
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
+ * @todo Try using some -1 control sizes so that items auto-size (maybe that will help with
+ *      redraw problems?)
+ * @todo Add some frames around things in the control panel
  */
 
 require_once __DIR__ . '/control.php';

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -16,6 +16,8 @@
  *     http://docs.wxwidgets.org/trunk/overview_sizer.html
  *
  * @todo Quit when the controller window is closed
+ * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
+ *      - something to do with the wrapping text control?
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
  * @todo Add some frames around things in the control panel
  * @todo A control window height of -1 doesn't work due to the text resize - maybe add in

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -16,8 +16,6 @@
  *     http://docs.wxwidgets.org/trunk/overview_sizer.html
  *
  * @todo Quit when the controller window is closed
- * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
- *      - something to do with the wrapping text control?
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
  * @todo Add some frames around things in the control panel
  */

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -28,6 +28,8 @@
  *      - make each FrameSizer a child of a new GridSizer
  *      - swap outer BoxSizer with FlexGridSizer with a single column
  *      - move window construction to Show()
+ * @todo Right-align the alignment menu drop-downs, so that the vertical dropdown sits flush
+ *      with the right hand edge of the frame (with an appropriate border of course)
  */
 
 require_once __DIR__ . '/control.php';

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -19,8 +19,6 @@
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
- * @todo Try using some -1 control sizes so that items auto-size (maybe that will help with
- *      redraw problems?)
  * @todo Add some frames around things in the control panel
  */
 

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -26,6 +26,7 @@
  *      - add in a GridSizer child to FrameSizers
  *      - make each FrameSizer a child of a new GridSizer
  *      - swap outer BoxSizer with FlexGridSizer with a single column
+ *      - add long dummy text to the static box sizer
  */
 
 require_once __DIR__ . '/control.php';

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -15,7 +15,6 @@
  *
  *     http://docs.wxwidgets.org/trunk/overview_sizer.html
  *
- * @todo Remove trailing space to labels to add extra horiz space
  * @todo Quit when the controller window is closed
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -18,6 +18,7 @@
  * @todo Quit when the controller window is closed
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?
+ *      - tried adding long dummy text to the static box sizer, no difference
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
  * @todo Add some frames around things in the control panel
  * @todo A control window height of -1 doesn't work due to the text resize - maybe add in
@@ -26,7 +27,7 @@
  *      - add in a GridSizer child to FrameSizers
  *      - make each FrameSizer a child of a new GridSizer
  *      - swap outer BoxSizer with FlexGridSizer with a single column
- *      - add long dummy text to the static box sizer
+ *      - move window construction to Show()
  */
 
 require_once __DIR__ . '/control.php';

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -18,6 +18,12 @@
  * @todo Quit when the controller window is closed
  * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
  * @todo Add some frames around things in the control panel
+ * @todo A control window height of -1 doesn't work due to the text resize - maybe add in
+ *      text to get this working and then null it?
+ * @todo StaticBoxSizer introduces GTK console warnings, tried a few things already:
+ *      - add in a GridSizer child to FrameSizers
+ *      - make each FrameSizer a child of a new GridSizer
+ *      - swap outer BoxSizer with FlexGridSizer with a single column
  */
 
 require_once __DIR__ . '/control.php';

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -12,7 +12,6 @@
  *     /usr/bin/php -d extension=wxwidgets.so sizers/main.php
  *
  * @todo Remove trailing space to labels to add extra horiz space
- * @todo Investigate Gtk-CRITICAL and Gtk-WARNING from checkboxes
  * @todo Quit when the controller window is closed
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?

--- a/examples/sizers/main.php
+++ b/examples/sizers/main.php
@@ -19,10 +19,6 @@
  * @todo I get very occasional redraw strangeness in the controller, but not often enough to debug
  *      - something to do with the wrapping text control?
  *      - tried adding long dummy text to the static box sizer, no difference
- * @todo Occasionally one of the drop-down menus does not draw properly - not wide enough?
- * @todo Add some frames around things in the control panel
- * @todo A control window height of -1 doesn't work due to the text resize - maybe add in
- *      text to get this working and then null it?
  * @todo StaticBoxSizer introduces GTK console warnings, tried a few things already:
  *      - add in a GridSizer child to FrameSizers
  *      - make each FrameSizer a child of a new GridSizer
@@ -30,8 +26,6 @@
  *      - move window construction to Show()
  *      - ** Ah, could wxEXPAND be the cause of these? Adding one resulted in 16 warnings
  *        ** instead of 8!
- * @todo Right-align the alignment menu drop-downs, so that the vertical dropdown sits flush
- *      with the right hand edge of the frame (with an appropriate border of course)
  */
 
 require_once __DIR__ . '/control.php';


### PR DESCRIPTION
This PR adds a few new sizer demonstrations (I'm learning as I go!) and adds some frames to group similar controls together in the control pane.

I'm stuck with some screen redraw issues in the control window only, do you get them? I'm happy for you to merge down straight away, but feedback on that would be welcome - this will help to see whether wxPHP is viable for the projects I'd like to use it for (I don't want to box myself in with something that turns out not to be rigorously stable, given that wxWidgets doesn't have a wide PHP userbase).

I get the redraw issues around 20% of the time, and clicking in the demo window (so the control window loses focus) forces a redraw and "fixes" it.
