### PR TITLE
Some minor improvements to the XRC demo

### DIFF
--- a/examples/XRC/forms.fbp
+++ b/examples/XRC/forms.fbp
@@ -99,7 +99,7 @@
                         <property name="font"></property>
                         <property name="hidden">0</property>
                         <property name="id">wxID_ANY</property>
-                        <property name="label">These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor.</property>
+                        <property name="label">These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor. Attaching to events is demonstrated by the OK and Cancel action buttons at the bottom of the form.</property>
                         <property name="maximum_size">-1,-1</property>
                         <property name="minimum_size">-1,-1</property>
                         <property name="name">staticHelp</property>

--- a/examples/XRC/forms.fbp
+++ b/examples/XRC/forms.fbp
@@ -82,7 +82,7 @@
                 <property name="growablerows"></property>
                 <property name="hgap">0</property>
                 <property name="minimum_size"></property>
-                <property name="name">fgSizer4</property>
+                <property name="name">sizerWholeForm</property>
                 <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
                 <property name="permission">none</property>
                 <property name="rows">6</property>
@@ -102,7 +102,7 @@
                         <property name="label">These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor.</property>
                         <property name="maximum_size">-1,-1</property>
                         <property name="minimum_size">-1,-1</property>
-                        <property name="name">m_staticText12</property>
+                        <property name="name">staticHelp</property>
                         <property name="permission">protected</property>
                         <property name="pos"></property>
                         <property name="size">480,-1</property>
@@ -150,7 +150,7 @@
                         <property name="id">wxID_ANY</property>
                         <property name="label">Colour</property>
                         <property name="minimum_size"></property>
-                        <property name="name">sbSizer1</property>
+                        <property name="name">sizerColour</property>
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
@@ -160,7 +160,7 @@
                             <property name="proportion">1</property>
                             <object class="wxBoxSizer" expanded="0">
                                 <property name="minimum_size"></property>
-                                <property name="name">bSizer9</property>
+                                <property name="name">bSizerColourInner</property>
                                 <property name="orient">wxHORIZONTAL</property>
                                 <property name="permission">none</property>
                                 <object class="sizeritem" expanded="1">
@@ -178,7 +178,7 @@
                                         <property name="label">Foreground:</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_staticText2</property>
+                                        <property name="name">staticColourForeground</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -233,7 +233,7 @@
                                         <property name="id">wxID_ANY</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">colPicker</property>
+                                        <property name="name">colPickerForeground</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -288,7 +288,7 @@
                                         <property name="label">Background:</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_staticText1</property>
+                                        <property name="name">staticColourBackground</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -343,7 +343,7 @@
                                         <property name="id">wxID_ANY</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_colourPicker3</property>
+                                        <property name="name">colPickerBackground</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -395,7 +395,7 @@
                         <property name="id">wxID_ANY</property>
                         <property name="label">Date/time</property>
                         <property name="minimum_size"></property>
-                        <property name="name">sbSizer2</property>
+                        <property name="name">sizerDate</property>
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
@@ -405,7 +405,7 @@
                             <property name="proportion">1</property>
                             <object class="wxBoxSizer" expanded="0">
                                 <property name="minimum_size"></property>
-                                <property name="name">bSizer4</property>
+                                <property name="name">sizerDateInner</property>
                                 <property name="orient">wxHORIZONTAL</property>
                                 <property name="permission">none</property>
                                 <object class="sizeritem" expanded="1">
@@ -423,7 +423,7 @@
                                         <property name="label">Date:</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_staticText21</property>
+                                        <property name="name">staticDate</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -477,7 +477,7 @@
                                         <property name="id">wxID_ANY</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_datePicker2</property>
+                                        <property name="name">datePicker</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -532,7 +532,7 @@
                                         <property name="label">Time:</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_staticText2111</property>
+                                        <property name="name">staticTime</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -589,7 +589,7 @@
                                         <property name="maximum_size">-1,-1</property>
                                         <property name="min">0</property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_spinCtrl1</property>
+                                        <property name="name">spinHours</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size">100,-1</property>
@@ -646,7 +646,7 @@
                                         <property name="label">:</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_staticText211</property>
+                                        <property name="name">staticTimeColon</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -703,7 +703,7 @@
                                         <property name="maximum_size">-1,-1</property>
                                         <property name="min">0</property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_spinCtrl2</property>
+                                        <property name="name">spinMinutes</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size">100,-1</property>
@@ -757,7 +757,7 @@
                         <property name="id">wxID_ANY</property>
                         <property name="label">Attachments</property>
                         <property name="minimum_size"></property>
-                        <property name="name">sbSizer4</property>
+                        <property name="name">sizerFiles</property>
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
@@ -776,7 +776,7 @@
                                 <property name="maximum_size"></property>
                                 <property name="message">Select a file</property>
                                 <property name="minimum_size"></property>
-                                <property name="name">m_filePicker2</property>
+                                <property name="name">filePicker</property>
                                 <property name="permission">protected</property>
                                 <property name="pos"></property>
                                 <property name="size"></property>
@@ -828,7 +828,7 @@
                         <property name="id">wxID_ANY</property>
                         <property name="label">Some radio buttons</property>
                         <property name="minimum_size"></property>
-                        <property name="name">sbSizer41</property>
+                        <property name="name">sizerRadio</property>
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
@@ -838,7 +838,7 @@
                             <property name="proportion">1</property>
                             <object class="wxBoxSizer" expanded="1">
                                 <property name="minimum_size"></property>
-                                <property name="name">bSizer5</property>
+                                <property name="name">sizerRadioInner</property>
                                 <property name="orient">wxHORIZONTAL</property>
                                 <property name="permission">none</property>
                                 <object class="sizeritem" expanded="1">
@@ -856,7 +856,7 @@
                                         <property name="label">Option 1</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_radioBtn1</property>
+                                        <property name="name">radioOption1</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -912,7 +912,7 @@
                                         <property name="label">Option 2</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_radioBtn2</property>
+                                        <property name="name">radioButton2</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -963,7 +963,7 @@
                     <property name="proportion">1</property>
                     <object class="wxBoxSizer" expanded="0">
                         <property name="minimum_size"></property>
-                        <property name="name">vertSizer</property>
+                        <property name="name">sizerActions</property>
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <object class="sizeritem" expanded="1">
@@ -991,7 +991,7 @@
                                         <property name="label">Cancel</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_button2</property>
+                                        <property name="name">actionCancel</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>
@@ -1047,7 +1047,7 @@
                                         <property name="label">OK</property>
                                         <property name="maximum_size"></property>
                                         <property name="minimum_size"></property>
-                                        <property name="name">m_button3</property>
+                                        <property name="name">actionOK</property>
                                         <property name="permission">protected</property>
                                         <property name="pos"></property>
                                         <property name="size"></property>

--- a/examples/XRC/forms.xrc.xml
+++ b/examples/XRC/forms.xrc.xml
@@ -17,7 +17,7 @@
 				<border>8</border>
 				<object class="wxStaticText" name="staticHelp">
 					<size>480,-1</size>
-					<label>These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor.</label>
+					<label>These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor. Attaching to events is demonstrated by the OK and Cancel action buttons at the bottom of the form.</label>
 				</object>
 			</object>
 			<object class="sizeritem">

--- a/examples/XRC/forms.xrc.xml
+++ b/examples/XRC/forms.xrc.xml
@@ -15,7 +15,7 @@
 				<option>0</option>
 				<flag>wxEXPAND|wxLEFT|wxRIGHT|wxTOP</flag>
 				<border>8</border>
-				<object class="wxStaticText" name="m_staticText12">
+				<object class="wxStaticText" name="staticHelp">
 					<size>480,-1</size>
 					<label>These controls don&apos;t really do anything - they&apos;re just to demonstrate loading windows and controls created using the wxFormEditor.</label>
 				</object>
@@ -37,7 +37,7 @@
 								<option>0</option>
 								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 								<border>5</border>
-								<object class="wxStaticText" name="m_staticText2">
+								<object class="wxStaticText" name="staticColourForeground">
 									<label>Foreground:</label>
 								</object>
 							</object>
@@ -45,7 +45,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxColourPickerCtrl" name="colPicker">
+								<object class="wxColourPickerCtrl" name="colPickerForeground">
 									<value>#000000</value>
 									<style>wxCLRP_DEFAULT_STYLE</style>
 								</object>
@@ -54,7 +54,7 @@
 								<option>0</option>
 								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 								<border>5</border>
-								<object class="wxStaticText" name="m_staticText1">
+								<object class="wxStaticText" name="staticColourBackground">
 									<label>Background:</label>
 								</object>
 							</object>
@@ -62,7 +62,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxColourPickerCtrl" name="m_colourPicker3">
+								<object class="wxColourPickerCtrl" name="colPickerBackground">
 									<value>#000000</value>
 									<style>wxCLRP_DEFAULT_STYLE</style>
 								</object>
@@ -88,7 +88,7 @@
 								<option>0</option>
 								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 								<border>5</border>
-								<object class="wxStaticText" name="m_staticText21">
+								<object class="wxStaticText" name="staticDate">
 									<label>Date:</label>
 								</object>
 							</object>
@@ -96,7 +96,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxDatePickerCtrl" name="m_datePicker2">
+								<object class="wxDatePickerCtrl" name="datePicker">
 									<style>wxDP_DEFAULT|wxDP_SHOWCENTURY</style>
 								</object>
 							</object>
@@ -104,7 +104,7 @@
 								<option>0</option>
 								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 								<border>5</border>
-								<object class="wxStaticText" name="m_staticText2111">
+								<object class="wxStaticText" name="staticTime">
 									<label>Time:</label>
 								</object>
 							</object>
@@ -112,7 +112,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxSpinCtrl" name="m_spinCtrl1">
+								<object class="wxSpinCtrl" name="spinHours">
 									<style>wxSP_ARROW_KEYS</style>
 									<size>100,-1</size>
 									<value>0</value>
@@ -124,7 +124,7 @@
 								<option>0</option>
 								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 								<border>5</border>
-								<object class="wxStaticText" name="m_staticText211">
+								<object class="wxStaticText" name="staticTimeColon">
 									<label>:</label>
 								</object>
 							</object>
@@ -132,7 +132,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxSpinCtrl" name="m_spinCtrl2">
+								<object class="wxSpinCtrl" name="spinMinutes">
 									<style>wxSP_ARROW_KEYS</style>
 									<size>100,-1</size>
 									<value>0</value>
@@ -155,7 +155,7 @@
 						<option>0</option>
 						<flag>wxALL</flag>
 						<border>5</border>
-						<object class="wxFilePickerCtrl" name="m_filePicker2">
+						<object class="wxFilePickerCtrl" name="filePicker">
 							<value></value>
 							<message>Select a file</message>
 							<wildcard>*.*</wildcard>
@@ -181,7 +181,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxRadioButton" name="m_radioBtn1">
+								<object class="wxRadioButton" name="radioOption1">
 									<label>Option 1</label>
 									<value>0</value>
 								</object>
@@ -190,7 +190,7 @@
 								<option>0</option>
 								<flag>wxALL</flag>
 								<border>5</border>
-								<object class="wxRadioButton" name="m_radioBtn2">
+								<object class="wxRadioButton" name="radioButton2">
 									<label>Option 2</label>
 									<value>0</value>
 								</object>
@@ -215,7 +215,7 @@
 								<option>0</option>
 								<flag>wxRIGHT</flag>
 								<border>5</border>
-								<object class="wxButton" name="m_button2">
+								<object class="wxButton" name="actionCancel">
 									<label>Cancel</label>
 									<default>0</default>
 								</object>
@@ -224,7 +224,7 @@
 								<option>0</option>
 								<flag></flag>
 								<border>5</border>
-								<object class="wxButton" name="m_button3">
+								<object class="wxButton" name="actionOK">
 									<label>OK</label>
 									<default>0</default>
 								</object>

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -23,7 +23,6 @@
  * the code. Another way to do this is to write a script to inject <wrap>460</wrap> into the
  * xrc file, but it's easier to do it here.
  *
- * @todo Quit application when dialogue box is closed
  * @todo Attach some event handlers
  * @todo Can spinners be auto-sized without being too wide (currently using a hard-coded
  *      width at present)
@@ -35,6 +34,26 @@ $app = new myApp();
 wxApp::SetInstance($app);
 wxEntry();
 
+/**
+ * Dialog windows don't seem to attract the "top level" window status that by default causes
+ * a WX application to quit automatically when they are closed. Accordingly we trap this event
+ * and exit manually
+ */
+class resourceDemoDialog extends wxDialog
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->Connect(wxEVT_CLOSE_WINDOW, array($this, "onWindowClose"));
+    }
+
+	public function onWindowClose(wxCloseEvent $event)
+	{
+        // Are there any wxWidgets tidy-up calls we need to make?
+        exit();
+    }
+}
+
 class myApp extends wxApp
 {
     public function OnInit()
@@ -43,7 +62,7 @@ class myApp extends wxApp
         $resource->InitAllHandlers();
         $resource->Load(__DIR__ . '/forms.xrc.xml');
         
-        $frame = new wxDialog();
+        $frame = new resourceDemoDialog();
         $resource->LoadDialog($frame, NULL, 'frmOne');
 
         // Re-wrap and re-fit the text control - this gets the correct amount of vertical

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -67,11 +67,11 @@ class resourceDemoDialog extends wxDialog
         $message = null;
         if ($buttonCtrl->GetName() === self::ELMT_CANCEL)
         {
-            $message = "Clicked cancel";
+            $message = "Clicked cancel: this would normally close the dialogue without taking any action";
         }
         elseif ($buttonCtrl->GetName() === self::ELMT_OK)
         {
-            $message = "Clicked OK";
+            $message = "Clicked OK: this would normally close the dialogue and take the usual action (e.g. creating a diary entry)";
         }
 
         // If we have a message, let's see it

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -25,6 +25,9 @@
  *
  * @todo Put in some more windows (a wxFrame perhaps)
  * @todo Put in some more controls e.g. tabs
+ * @todo I've noticed that the XRC format is similar to the FBP save output from wxFormBuilder -
+ *      would be interesting to write a script to auto-convert one to the other, perhaps using
+ *      inotify-tools to watch the source file and to keep the XRC in sync
  * @todo Can spinners be auto-sized without being too wide? (currently using a hard-coded
  *      width at present)
  */

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -23,11 +23,10 @@
  * the code. Another way to do this is to write a script to inject <wrap>460</wrap> into the
  * xrc file, but it's easier to do it here.
  *
- * @todo Attach some event handlers
- * @todo Can spinners be auto-sized without being too wide (currently using a hard-coded
- *      width at present)
+ * @todo Put in some more windows (a wxFrame perhaps)
  * @todo Put in some more controls e.g. tabs
- * @todo Put in some more windows
+ * @todo Can spinners be auto-sized without being too wide? (currently using a hard-coded
+ *      width at present)
  */
 
 $app = new myApp();

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -23,7 +23,6 @@
  * the code. Another way to do this is to write a script to inject <wrap>460</wrap> into the
  * xrc file, but it's easier to do it here.
  *
- * @todo Tidy up the names of elements in the editor
  * @todo Quit application when dialogue box is closed
  * @todo Attach some event handlers
  * @todo Can spinners be auto-sized without being too wide (currently using a hard-coded
@@ -50,7 +49,7 @@ class myApp extends wxApp
         // Re-wrap and re-fit the text control - this gets the correct amount of vertical
         // size for the wrapped text and its borders
         $textCtrl = wxDynamicCast(
-            $frame->FindWindow('m_staticText12'),
+            $frame->FindWindow('staticHelp'),
             "wxStaticText"
         );
         $textCtrl->Wrap(460);

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -55,8 +55,8 @@ class resourceDemoDialog extends wxDialog
         $this->Connect(wxEVT_COMMAND_BUTTON_CLICKED, array($this, "onButtonClick"));
     }
 
-	public function onWindowClose(wxCloseEvent $event)
-	{
+    public function onWindowClose(wxCloseEvent $event)
+    {
         // Are there any wxWidgets tidy-up calls we need to make?
         exit();
     }

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -41,16 +41,44 @@ wxEntry();
  */
 class resourceDemoDialog extends wxDialog
 {
+    const ELMT_CANCEL = 'actionCancel';
+    const ELMT_OK = 'actionOK';
+
     public function __construct()
     {
         parent::__construct();
+
+        // Attach some GUI event handlers
         $this->Connect(wxEVT_CLOSE_WINDOW, array($this, "onWindowClose"));
+        $this->Connect(wxEVT_COMMAND_BUTTON_CLICKED, array($this, "onButtonClick"));
     }
 
 	public function onWindowClose(wxCloseEvent $event)
 	{
         // Are there any wxWidgets tidy-up calls we need to make?
         exit();
+    }
+
+    public function onButtonClick($event)
+    {
+        $buttonCtrl = wxDynamicCast($event->GetEventObject(), "wxButton");
+
+        // We use the element names to recognise them - easier than using IDs
+        $message = null;
+        if ($buttonCtrl->GetName() === self::ELMT_CANCEL)
+        {
+            $message = "Clicked cancel";
+        }
+        elseif ($buttonCtrl->GetName() === self::ELMT_OK)
+        {
+            $message = "Clicked OK";
+        }
+
+        // If we have a message, let's see it
+        if ($message)
+        {
+            wxMessageBox($message);
+        }
     }
 }
 

--- a/examples/XRC/main.php
+++ b/examples/XRC/main.php
@@ -24,6 +24,7 @@
  * xrc file, but it's easier to do it here.
  *
  * @todo Tidy up the names of elements in the editor
+ * @todo Quit application when dialogue box is closed
  * @todo Attach some event handlers
  * @todo Can spinners be auto-sized without being too wide (currently using a hard-coded
  *      width at present)


### PR DESCRIPTION
A few extra items for this one:

* Element names are now meaningful
* There is now a demonstration of how to attach frame and element event handlers. I use names rather than IDs, which seems cleaner to me
* The application quits when the dialogue is closed

One area I would highlight is quitting the application - I could not find a way to notify WX to close down, so I am using `exit()` and hoping its destructors will do the job. If there is a better way to do this, let me know and I'll send another commit in the same PR.
